### PR TITLE
Gp 909 school error

### DIFF
--- a/__tests__/components/SchoolsLookUp/SchoolsLookUp.spec.js
+++ b/__tests__/components/SchoolsLookUp/SchoolsLookUp.spec.js
@@ -130,14 +130,10 @@ test('search and recieve empty results', () => {
     expect(component.find('[name="spinner"]').exists()).toBe(false);
     // assert no results are recieved
     expect(component.state('options')).toEqual([]);
-
-    // render menu list where no results found message is expected to be displayed
-    const instance = component.setState({ query: 'testquery' }).instance();
-    const emptyLabel = "Sorry, that postcode isn't in our database of schools and nurseries. Please manually fill in the address below.";
-    const menu = render(instance.renderMenu([], { emptyLabel, text: 'testquery' }));
+    const emptyLabel = "Sorry, we can't find this. Please check your school or postcode is correct and manually add the address below.";
 
     // assert no results message is displayed
-    expect(menu.text()).toEqual(emptyLabel);
+    expect(component.text()).toContain(emptyLabel);
   });
 });
 

--- a/__tests__/components/SchoolsLookUp/SchoolsLookUp.spec.js
+++ b/__tests__/components/SchoolsLookUp/SchoolsLookUp.spec.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React from 'react';
-import { shallow, render } from 'enzyme';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import SchoolsLookUp from '../../../src/components/SchoolsLookUp/SchoolsLookUp';
 

--- a/src/components/SchoolsLookUp/SchoolsLookUp.js
+++ b/src/components/SchoolsLookUp/SchoolsLookUp.js
@@ -322,10 +322,9 @@ class SchoolsLookUp extends Component {
    * @return {XML}
    */
   renderMenu(results, menuProps) {
-    const { isSearching, isDefaultOptionHighlighted, query } = this.state;
+    const { isSearching, isDefaultOptionHighlighted } = this.state;
     // do not show results until search is complete
-    if (menuProps.emptyLabel === 'Searching...' || isSearching === true ||
-        (results.length === 0 && query && query.toUpperCase() !== menuProps.text.toUpperCase())
+    if (menuProps.emptyLabel === 'Searching...' || isSearching === true || results.length === 0
     ) {
       return <div />;
     }
@@ -363,7 +362,7 @@ class SchoolsLookUp extends Component {
       establishmentNameIdentifier, address1Identifier, address2Identifier, address3Identifier,
       townIdentifier, postcodeIdentifier, min, selectedEstablishment, disabled,
     } = this.props;
-    const { lookup, options, isSearching } = this.state;
+    const { lookup, options, isSearching, query } = this.state;
     const orEnterManuallyCopy = 'Or enter details manually';
 
     return (
@@ -394,7 +393,7 @@ class SchoolsLookUp extends Component {
               type="text"
               minLength={min}
               bsSize="large"
-              emptyLabel="Sorry, that postcode isn't in our database of schools and nurseries. Please manually fill in the address below."
+              emptyLabel=""
               onSearch={this.handleSearch}
               onChange={this.handleChange}
               onInputChange={this.handleInputChange}
@@ -409,6 +408,12 @@ class SchoolsLookUp extends Component {
             />
             {isSearching ?
               <Icon name="spinner" spin />:
+              null
+            }
+            {!isSearching && query.length > min && options.length === 0 ?
+              <p className="font--red">
+                {"Sorry, we can't find this. Please check your school or postcode is correct and manually add the address below."}
+              </p>:
               null
             }
           </div>


### PR DESCRIPTION
AsyncTypeahead used to handle empty results message,
it displayed the message as a dropdown, that's why it hided the manual entry link

Fix: handle error message display manually,
by checking if search query's length is higher than minimum ,search is done and returned resultset is empty, then error message should be displayed as a normal paragraph above manual entry link