### PR TITLE
InputField component

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@storybook/addon-knobs": "3",
     "@storybook/react": "3",
     "axios": "0",
+    "babel-polyfill": "^6.26.0",
     "enzyme": "2",
     "expect": "21",
     "prop-types": "15",

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -1,0 +1,99 @@
+/* eslint-env browser */
+import React, { Component } from 'react';
+import propTypes from 'prop-types';
+import fieldValidation from './validation';
+
+/**
+ * InputField class
+ * Requires a shape containing required and optional items defining the type of input field.
+ * See propTypes below.
+ */
+class InputField extends Component {
+  constructor() {
+    super();
+    // this.inputField = React.createRef();
+    this.validateField = this.validateField.bind(this);
+    this.state = {
+      valid: null,
+      message: '',
+    };
+  }
+
+  /**
+   * Calls helper function to validate the input field
+   * Sets the the state for the validation and validation message
+   */
+  validateField(e) {
+    const props = {
+      field: e.target,
+      fieldProps: this.props.field,
+    };
+    let validation = this.state;
+    // helper function will return an updated validation object
+    validation = fieldValidation(props, validation);
+    this.setState(validation);
+  }
+  render() {
+    return (
+      <div id={`field-wrapper--${this.props.field.id}`} className={`form__fieldset form__field-wrapper form__field-wrapper--${this.props.field.type} ${this.props.field.extraClass ? this.props.field.extraClass : ''}`}>
+        <label id={`field-label--${this.props.field.id}`} htmlFor={`field-input--${this.props.field.id}`} className={`form__field-label${this.props.field.required ? ' required' : ''}`}>
+          {this.props.field.label}
+        </label>
+        {!this.props.field.required &&
+        <span>&nbsp;(Optional)&nbsp;</span>
+        }
+        {this.props.field.helpText !== undefined &&
+        <span className="form-help-text">{this.props.field.helpText}</span>
+        }
+        <input
+          ref={this.inputField}
+          type={this.props.field.type}
+          id={`field-input--${this.props.field.id}`}
+          className={`form__field form__field--${this.props.field.type} ${this.state.valid ? '' : 'error'} ${this.props.field.extraClass ? this.props.field.extraClass : ''} `}
+          required={this.props.field.required && this.props.field.required}
+          placeholder={this.props.field.placeholder && this.props.field.placeholder}
+          min={this.props.field.min && this.props.field.min}
+          max={this.props.field.max && this.props.field.max}
+          onBlur={this.props.field.type !== 'checkbox' ? this.validateField : undefined}
+          onChange={this.props.field.required && this.props.field.type === 'checkbox' ? this.validateField : undefined}
+        />
+        {this.props.field.type === 'checkbox' &&
+        // span for checkbox styling
+        <span />
+        }
+        {this.state.valid === false &&
+        <div
+          id={`field-error--${this.props.field.id}`}
+          className={`form__field-error-container form__field-error-container--${this.props.field.type}`}
+        >
+          <span className="form-error">
+            {this.state.message}
+          </span>
+        </div>
+        }
+      </div>
+    );
+  }
+}
+
+
+InputField.propTypes = {
+  field: propTypes.shape({
+    id: propTypes.string.isRequired,
+    type: propTypes.string.isRequired,
+    name: propTypes.string.isRequired,
+    label: propTypes.string.isRequired,
+    required: propTypes.bool.isRequired,
+    pattern: propTypes.string,
+    placeholder: propTypes.string,
+    min: propTypes.number,
+    max: propTypes.number,
+    checked: propTypes.bool,
+    extraClass: propTypes.string,
+    helpText: propTypes.string,
+    emptyFieldErrorText: propTypes.string,
+    invalidErrorText: propTypes.string,
+  }).isRequired,
+};
+
+export default InputField;

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -54,6 +54,7 @@ class InputField extends Component {
           placeholder={this.props.field.placeholder && this.props.field.placeholder}
           min={this.props.field.min && this.props.field.min}
           max={this.props.field.max && this.props.field.max}
+          aria-describedby={`field-label--${this.props.field.id} field-error--${this.props.field.id}`}
           onBlur={this.props.field.type !== 'checkbox' ? this.validateField : undefined}
           onChange={this.props.field.required && this.props.field.type === 'checkbox' ? this.validateField : undefined}
         />
@@ -65,6 +66,8 @@ class InputField extends Component {
         <div
           id={`field-error--${this.props.field.id}`}
           className={`form__field-error-container form__field-error-container--${this.props.field.type}`}
+          aria-live="assertive"
+          role="status"
         >
           <span className="form-error">
             {this.state.message}

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -38,10 +38,10 @@ class InputField extends Component {
       <div id={`field-wrapper--${this.props.field.id}`} className={`form__fieldset form__field-wrapper form__field-wrapper--${this.props.field.type} ${this.props.field.extraClass ? this.props.field.extraClass : ''}`}>
         <label id={`field-label--${this.props.field.id}`} htmlFor={`field-input--${this.props.field.id}`} className={`form__field-label${this.props.field.required ? ' required' : ''}`}>
           {this.props.field.label}
+          {!this.props.field.required &&
+          <span>&nbsp;(Optional)&nbsp;</span>
+          }
         </label>
-        {!this.props.field.required &&
-        <span>&nbsp;(Optional)&nbsp;</span>
-        }
         {this.props.field.helpText !== undefined &&
         <span className="form-help-text">{this.props.field.helpText}</span>
         }

--- a/src/components/InputField/package.json
+++ b/src/components/InputField/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "InputField",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./InputField.js",
+  "dependencies": {
+    "react": "^15.6.1",
+    "prop-types": "^15.5.10"
+  }
+}

--- a/src/components/InputField/package.json
+++ b/src/components/InputField/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "./InputField.js",
   "dependencies": {
-    "react": "^15.6.1",
-    "prop-types": "^15.5.10"
+    "react": "^16.3.1",
+    "prop-types": "^15.6.1"
   }
 }

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -64,11 +64,11 @@ function getMessage(input, fieldProps, value) {
         const min = fieldProps.min;
         const max = fieldProps.max;
         if ((!min && max) && (input === 'empty' || value > max)) {
-          message = input === 'empty' ? 'Please fill in a value below ' + max : 'This fields only accepts a number below ' + max;
+          message = input === 'empty' ? `Please fill in a value below ${max}` : `This fields only accepts a number below ${max}`;
         } else if ((min && !max) && (input === 'empty' || value < min)) {
-          message = input === 'empty' ? 'Please fill in a value above' + min : 'This fields only accepts a number above ' + min;
+          message = input === 'empty' ? `Please fill in a value above ${min}` : `This fields only accepts a number above ${min}`;
         } else if ((min && max) && (input === 'empty' || (value < min || value > max))) {
-          message = input === 'empty' ? 'Please fill in a value between ' + min + ' and ' + max : '\'This fields only accepts a number between ' + min + ' and ' + max;
+          message = input === 'empty' ? `Please fill in a value between ${min} and ${max}` : `This fields only accepts a number between ${min} and ${max}`;
         } else {
           message = 'Please enter a number';
         }
@@ -95,19 +95,20 @@ function getMessage(input, fieldProps, value) {
  * returns validation object containing whether the field is valid and an error message
  */
 export default function fieldValidation(props, validation) {
+  const updatedValidation = validation;
   const type = props.field.getAttribute('type');
   const value = type === 'checkbox' ? props.field.checked : props.field.value;
   const emptyField = isEmpty(value, props.fieldProps.required, type);
   if (emptyField === true) {
-    validation.valid = false;
-    validation.message = getMessage('empty', props.fieldProps);
+    updatedValidation.valid = false;
+    updatedValidation.message = getMessage('empty', props.fieldProps);
   } else if (emptyField === false) {
     const validInput = isValidInput(type, props.fieldProps, value);
-    validation.valid = validInput !== false;
-    validation.message = validInput === false ? getMessage('invalid', props.fieldProps, value) : '';
+    updatedValidation.valid = validInput !== false;
+    updatedValidation.message = validInput === false ? getMessage('invalid', props.fieldProps, value) : '';
   } else {
-    validation.valid = true;
-    validation.message = '';
+    updatedValidation.valid = true;
+    updatedValidation.message = '';
   }
   return validation;
 }

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -1,0 +1,114 @@
+const defaultValidationPatterns = {
+  tel: '^[0-9 ]+$',
+  number: '^[0-9]+$',
+  email: '^[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,3}$',
+  text: '^[A-Za-z0-9]+$',
+};
+
+function isEmpty(value, required, type) {
+  let empty;
+  if (required === true && (!value || value === false)) {
+    empty = true;
+  } else if (value && type !== 'checkbox') {
+    empty = false;
+  }
+  return empty;
+}
+
+function isValidInput(type, fieldProps, value) {
+  let valid;
+  // use pattern override if it's defined, otherwise use default pattern above
+  const patternOverride = fieldProps.pattern;
+  const pattern = patternOverride !== undefined ?
+    new RegExp(patternOverride) : new RegExp(defaultValidationPatterns[type]);
+  if (type === 'number') {
+    // Number fields need to not only pass the regex test,
+    // but also pass min and max values allowed if they're set.
+    const min = fieldProps.min;
+    const max = fieldProps.max;
+    const valueIsNumber = pattern.test(value);
+    if (valueIsNumber === true) {
+      // Value passes regex test.
+      // Check if min or max or both exist and value passes accordingly
+      if ((!min && max && value <= max) ||
+        (min && !max && value >= min) ||
+        (min && max && (value >= min && value <= max))) {
+        // value is within the min/max boundaries
+        valid = true;
+      } else {
+        // value is outside min/max boundaries
+        valid = false;
+      }
+    } else {
+      // value doesn't pass regex test
+      valid = false;
+    }
+  } else {
+    // Other input fields just have to pass the regex test
+    valid = pattern.test(value);
+  }
+
+  return valid;
+}
+
+function getMessage(input, fieldProps, value) {
+  // Input can be empty or invalid.
+  // Use error message override if available otherwise use default empty/invalid message
+  let message = input === 'empty' ? fieldProps.emptyFieldErrorText : fieldProps.invalidErrorText;
+  if (message === undefined) {
+    // Default error messages are based on the type of input field
+    // and whether the input is empty or invalid
+    switch (fieldProps.type) {
+      case 'number': {
+        // Number field's error message contains min and max value messages if they're set
+        const min = fieldProps.min;
+        const max = fieldProps.max;
+        if ((!min && max) && (input === 'empty' || value > max)) {
+          message = input === 'empty' ? 'Please fill in a value below ' + max : 'This fields only accepts a number below ' + max;
+        } else if ((min && !max) && (input === 'empty' || value < min)) {
+          message = input === 'empty' ? 'Please fill in a value above' + min : 'This fields only accepts a number above ' + min;
+        } else if ((min && max) && (input === 'empty' || (value < min || value > max))) {
+          message = input === 'empty' ? 'Please fill in a value between ' + min + ' and ' + max : '\'This fields only accepts a number between ' + min + ' and ' + max;
+        } else {
+          message = 'Please enter a number';
+        }
+        break;
+      }
+      case 'tel':
+      case 'email':
+        message = input === 'empty' ? `Please fill in your ${fieldProps.name}` : `Please fill in a valid ${fieldProps.name}`;
+        break;
+      case 'checkbox':
+        message = `Please check the ${fieldProps.name} checkbox`;
+        break;
+      case 'text':
+      default:
+        message = input === 'empty' ? `Please fill in your ${fieldProps.name}` : 'This field only accepts alphanumeric characters';
+        break;
+    }
+  }
+  return message;
+}
+
+/**
+ * Validate input fields
+ * returns validation object containing whether the field is valid and an error message
+ */
+export default function fieldValidation(props, validation) {
+  const type = props.field.getAttribute('type');
+  const value = type === 'checkbox' ? props.field.checked : props.field.value;
+  const emptyField = isEmpty(value, props.fieldProps.required, type);
+  if (emptyField === true) {
+    validation.valid = false;
+    validation.message = getMessage('empty', props.fieldProps);
+  } else if (emptyField === false) {
+    const validInput = isValidInput(type, props.fieldProps, value);
+    validation.valid = validInput !== false;
+    validation.message = validInput === false ? getMessage('invalid', props.fieldProps, value) : '';
+  } else {
+    validation.valid = true;
+    validation.message = '';
+  }
+  return validation;
+}
+

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -64,11 +64,11 @@ function getMessage(input, fieldProps, value) {
         const min = fieldProps.min;
         const max = fieldProps.max;
         if ((!min && max) && (input === 'empty' || value > max)) {
-          message = input === 'empty' ? `Please fill in a value below ${max}` : `This fields only accepts a number below ${max}`;
+          message = input === 'empty' ? `Please fill in a value below ${max}` : `This field only accepts a number below ${max}`;
         } else if ((min && !max) && (input === 'empty' || value < min)) {
-          message = input === 'empty' ? `Please fill in a value above ${min}` : `This fields only accepts a number above ${min}`;
+          message = input === 'empty' ? `Please fill in a value above ${min}` : `This field only accepts a number above ${min}`;
         } else if ((min && max) && (input === 'empty' || (value < min || value > max))) {
-          message = input === 'empty' ? `Please fill in a value between ${min} and ${max}` : `This fields only accepts a number between ${min} and ${max}`;
+          message = input === 'empty' ? `Please fill in a value between ${min} and ${max}` : `This field only accepts a number between ${min} and ${max}`;
         } else {
           message = 'Please enter a number';
         }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,11 +1,13 @@
 import FileUp from './FileUp/FileUp';
 import Footer from './Footer/Footer';
+import InputField from './InputField/InputField';
 import SchoolsLookUp from './SchoolsLookUp/SchoolsLookUp';
 import GrantsNearYou from './GrantsNearYou/GrantsNearYou';
 import GrantsInfographics from './GrantsInfographics/GrantsInfographics';
 
 export {
   Footer,
+  InputField,
   SchoolsLookUp,
   FileUp,
   GrantsNearYou,

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -5,7 +5,7 @@ import { specs, describe, it } from 'storybook-addon-specifications';
 import { mount } from 'enzyme';
 import expect from 'expect';
 
-import { withKnobs, text, number } from '@storybook/addon-knobs';
+import { withKnobs, text, number, object } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import Footer from '../components/Footer/Footer';
 import InputField from '../components/InputField/InputField';
@@ -162,65 +162,64 @@ storiesOf('Input Field', module)
   .addDecorator(withKnobs)
   .add('Text Field',
     withInfo('Text input')(() => {
-      const textField = {
+      const textField = object('field', {
         id: 'textfield',
         type: 'text',
-        name: 'text field',
-        label: 'Text field',
+        name: '[name of field]',
+        label: 'Text field label',
         required: true,
-      };
+      });
       return (<InputField field={textField} />);
     }),
   )
   .add('Number Field',
     withInfo('Number input')(() => {
-      const numberField = {
+      const numberField = object('field', {
         id: 'numberfield',
         type: 'number',
-        name: 'number field',
-        label: 'Number field',
+        name: '[name of field]',
+        label: 'Number field label',
         required: true,
         min: 1,
         max: 5000,
-      };
+      });
       return (<InputField field={numberField} />);
     }),
   )
   .add('Checkbox',
     withInfo('Checkbox')(() => {
-      const checkbox = {
+      const checkbox = object('field', {
         id: 'checkbox',
         type: 'checkbox',
-        name: 'checkbox field',
-        label: 'Checkbox',
+        name: '[name of field]',
+        label: 'Checkbox label',
         required: true,
 
-      };
+      });
       return (<InputField field={checkbox} />);
     }),
   )
   .add('Email Field',
     withInfo('Email field')(() => {
-      const email = {
+      const email = object('field', {
         id: 'email',
         type: 'email',
-        name: 'email field',
-        label: 'Email field',
+        name: '[name of field]',
+        label: 'Email field label',
         required: true,
-
-      };
+      });
       return (<InputField field={email} />);
     }),
   )
   .add('Telephone Field',
     withInfo('Telephone field')(() => {
-      const tel = {
+      const tel = object('field', {
         id: 'telephone',
         type: 'tel',
-        name: 'telephone field',
-        label: 'Telephone field',
+        name: '[name of field]',
+        label: 'Telephone field label',
         required: true,
-      };
+      });
       return (<InputField field={tel} />);
     }),
   );

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -8,6 +8,7 @@ import expect from 'expect';
 import { withKnobs, text, number } from '@storybook/addon-knobs';
 import { withInfo } from '@storybook/addon-info';
 import Footer from '../components/Footer/Footer';
+import InputField from '../components/InputField/InputField';
 import SchoolsLookUpContainer from '../components/SchoolsLookUp/SchoolsLookUpContainer';
 import FileUp from '../components/FileUp/FileUp';
 import GrantsNearYou from '../components/GrantsNearYou/GrantsNearYou';
@@ -157,7 +158,72 @@ storiesOf('Footer', module)
       return (<Footer copy={copy} source={source} campaign={campaign} />);
     }),
   );
+storiesOf('Input Field', module)
+  .addDecorator(withKnobs)
+  .add('Text Field',
+    withInfo('Text input')(() => {
+      const textField = {
+        id: 'textfield',
+        type: 'text',
+        name: 'text field',
+        label: 'Text field',
+        required: true,
+      };
+      return (<InputField field={textField} />);
+    }),
+  )
+  .add('Number Field',
+    withInfo('Number input')(() => {
+      const numberField = {
+        id: 'numberfield',
+        type: 'number',
+        name: 'number field',
+        label: 'Number field',
+        required: true,
+        min: 1,
+        max: 5000,
+      };
+      return (<InputField field={numberField} />);
+    }),
+  )
+  .add('Checkbox',
+    withInfo('Checkbox')(() => {
+      const checkbox = {
+        id: 'checkbox',
+        type: 'checkbox',
+        name: 'checkbox field',
+        label: 'Checkbox',
+        required: true,
 
+      };
+      return (<InputField field={checkbox} />);
+    }),
+  )
+  .add('Email Field',
+    withInfo('Email field')(() => {
+      const email = {
+        id: 'email',
+        type: 'email',
+        name: 'email field',
+        label: 'Email field',
+        required: true,
+
+      };
+      return (<InputField field={email} />);
+    }),
+  )
+  .add('Telephone Field',
+    withInfo('Telephone field')(() => {
+      const tel = {
+        id: 'telephone',
+        type: 'tel',
+        name: 'telephone field',
+        label: 'Telephone field',
+        required: true,
+      };
+      return (<InputField field={tel} />);
+    }),
+  );
 storiesOf('File Upload', module)
   .addDecorator(withKnobs)
   .add('Single',


### PR DESCRIPTION
fixes: #112 

Input field which can be reused in other components like specific form sections  (e.g. personal details section).

- needs a shape containing at least and id - type - name - label - required. 
- other properties can be added optionally (like placeholder, min max values)
- default validation pattern and error messages can be overridden. 