### PR TITLE
Change error messages there are still issues with IE and FF with screen readers

### DIFF
--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -202,7 +202,7 @@ class InputField extends Component {
     const extraClassName = this.props.extraClass !== '' ? this.props.extraClass : '';
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert', 'aria-relevant': 'all' } : { role: 'status' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>
@@ -254,7 +254,6 @@ class InputField extends Component {
             <div
               id={`field-error--${this.props.id}`}
               className={`form__field-error-container form__field-error-container--${this.props.type}`}
-              aria-live="assertive"
               {...supportedAriaAttributes}
             >
               <span className="form-error">

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -202,6 +202,7 @@ class InputField extends Component {
     const extraClassName = this.props.extraClass !== '' ? this.props.extraClass : '';
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
+    const isError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
     const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
@@ -233,7 +234,7 @@ class InputField extends Component {
               onChange={e => this.handleInputValidation(e)}
               ref={this.setRef}
               value={this.state.value}
-              aria-invalid={(this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== ''))}
+              aria-invalid={isError}
             />
             {this.props.inlineButton === true &&
             <div className="form__btn">
@@ -251,7 +252,7 @@ class InputField extends Component {
             <span />
             }
           </div>
-          {(this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '')) &&
+          { isError &&
             <div
               id={`field-error--${this.props.id}`}
               className={`form__field-error-container form__field-error-container--${this.props.type}`}

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -229,7 +229,7 @@ class InputField extends Component {
               max={this.props.max && this.props.max}
               defaultChecked={this.props.defaultChecked && this.props.defaultChecked}
               pattern={this.props.pattern && this.props.pattern}
-              aria-describedby={`field-error-text--${this.props.id} field-error--${this.props.id}`}
+              aria-describedby={`field-label--${this.props.id} field-error--${this.props.id}`}
               onBlur={e => this.handleInputValidation(e)}
               onChange={e => this.handleInputValidation(e)}
               ref={this.setRef}
@@ -258,7 +258,7 @@ class InputField extends Component {
               className={`form__field-error-container form__field-error-container--${this.props.type}`}
               {...supportedAriaAttributes}
             >
-              <span className="form-error" id={`field-error-text--${this.props.id}`}>
+              <span className="form-error" id={`field-label--${this.props.id}`}>
                 {this.state.message}
               </span>
             </div>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -202,7 +202,7 @@ class InputField extends Component {
     const extraClassName = this.props.extraClass !== '' ? this.props.extraClass : '';
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { 'aria-live': 'assertive' } : { 'aria-live': 'assertive' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -203,7 +203,7 @@ class InputField extends Component {
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
     const hasError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert' } : { 'aria-live': 'assertive', role: 'status' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -204,7 +204,7 @@ class InputField extends Component {
     const isBrowser = browser();
     const hasError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
     const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ?
-      { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
+      { role: 'alert', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -202,7 +202,7 @@ class InputField extends Component {
     const extraClassName = this.props.extraClass !== '' ? this.props.extraClass : '';
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
-    const isError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
+    const hasError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
     const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
@@ -234,7 +234,7 @@ class InputField extends Component {
               onChange={e => this.handleInputValidation(e)}
               ref={this.setRef}
               value={this.state.value}
-              aria-invalid={isError}
+              aria-invalid={hasError}
             />
             {this.props.inlineButton === true &&
             <div className="form__btn">
@@ -252,13 +252,13 @@ class InputField extends Component {
             <span />
             }
           </div>
-          { isError &&
+          { hasError &&
             <div
               id={`field-error--${this.props.id}`}
               className={`form__field-error-container form__field-error-container--${this.props.type}`}
               {...supportedAriaAttributes}
             >
-              <span className="form-error" id={`field-label--${this.props.id}`}>
+              <span className="form-error">
                 {this.state.message}
               </span>
             </div>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -204,7 +204,7 @@ class InputField extends Component {
     const isBrowser = browser();
     const hasError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
     const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ?
-      { role: 'alert', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
+      { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -202,7 +202,7 @@ class InputField extends Component {
     const extraClassName = this.props.extraClass !== '' ? this.props.extraClass : '';
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { 'aria-live': 'assertive' } : { 'aria-live': 'assertive' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>
@@ -228,11 +228,12 @@ class InputField extends Component {
               max={this.props.max && this.props.max}
               defaultChecked={this.props.defaultChecked && this.props.defaultChecked}
               pattern={this.props.pattern && this.props.pattern}
-              aria-describedby={`field-label--${this.props.id} field-error--${this.props.id}`}
+              aria-describedby={`field-error-text--${this.props.id} field-error--${this.props.id}`}
               onBlur={e => this.handleInputValidation(e)}
               onChange={e => this.handleInputValidation(e)}
               ref={this.setRef}
               value={this.state.value}
+              aria-invalid={(this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== ''))}
             />
             {this.props.inlineButton === true &&
             <div className="form__btn">
@@ -256,7 +257,7 @@ class InputField extends Component {
               className={`form__field-error-container form__field-error-container--${this.props.type}`}
               {...supportedAriaAttributes}
             >
-              <span className="form-error">
+              <span className="form-error" id={`field-error-text--${this.props.id}`}>
                 {this.state.message}
               </span>
             </div>

--- a/src/components/InputField/InputField.js
+++ b/src/components/InputField/InputField.js
@@ -203,7 +203,8 @@ class InputField extends Component {
     const error = this.props.showErrorMessage === true && this.state.message !== '' ? 'form__field--error-outline' : '';
     const isBrowser = browser();
     const hasError = this.state.valid === false || (this.props.showErrorMessage === true && this.state.message !== '');
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ?
+      { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div id={`field-wrapper--${this.props.id}`}>
@@ -234,7 +235,6 @@ class InputField extends Component {
               onChange={e => this.handleInputValidation(e)}
               ref={this.setRef}
               value={this.state.value}
-              aria-invalid={hasError}
             />
             {this.props.inlineButton === true &&
             <div className="form__btn">

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -397,7 +397,7 @@ class PostcodeLookup extends Component {
         <div
           ref={this.setAddressDetailRef}
           id="address-detail"
-          className="form__fieldset form__field--address-detail"
+          className="form__field--address-detail"
         >
           {
             this.state.isHidden === false &&

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -337,7 +337,6 @@ class PostcodeLookup extends Component {
    * @return {*}
    */
   render() {
-    // console.log(this.state.isHidden);
     const postCodeField = {
       id: 'postcode',
       type: 'text',

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -20,7 +20,7 @@ class PostcodeLookup extends Component {
       postcodeValidationMessage: false,
       showErrorMessages: false,
       previousAddress: '',
-      addressSelectClass: 'visually-hidden',
+      isAddressSelectHidden: true,
       isHidden: true,
       validation: {
         postcode: {
@@ -96,7 +96,6 @@ class PostcodeLookup extends Component {
         showErrorMessages: nextProps.showErrorMessages,
       });
       if (nextProps.showErrorMessages === true) {
-        // this.removeClassName(this.addressDetailRef, 'visually-hidden');
         this.setState({
           ...this.state,
           showErrorMessages: true,
@@ -183,7 +182,7 @@ class PostcodeLookup extends Component {
         value: item }));
     this.setState({
       addressDropdownList: addresses,
-      addressSelectClass: '',
+      isAddressSelectHidden: false,
     });
   }
 
@@ -379,17 +378,19 @@ class PostcodeLookup extends Component {
           buttonClick={() => { return this.addressLookup().then(() => this.returnPostcodeValidation()); }}
           showErrorMessage={this.state.showErrorMessages}
         />
-        <SelectField
-          ref={this.setRefs}
-          id="addressSelect"
-          name="addressSelect"
-          label="Select your address"
-          required={false}
-          options={this.state.addressDropdownList}
-          extraClass={this.state.addressSelectClass}
-          showErrorMessage={this.state.showErrorMessages}
-          isValid={(valid, name, value) => { this.updateAddress(value); }}
-        />
+        { this.state.isAddressSelectHidden === false &&
+          <SelectField
+            ref={this.setRefs}
+            id="addressSelect"
+            name="addressSelect"
+            label="Select your address"
+            required={false}
+            options={this.state.addressDropdownList}
+            extraClass={this.state.addressSelectClass}
+            showErrorMessage={this.state.showErrorMessages}
+            isValid={(valid, name, value) => { this.updateAddress(value); }}
+          />
+        }
         <div className="form__field--wrapper">
           <a href="/" role="button" className="link" onClick={e => this.showAddressFields(e)}>Or enter your address manually</a>
         </div>

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -279,7 +279,7 @@ class PostcodeLookup extends Component {
               message: '',
             },
           },
-          isHidden: false,
+          isAddressFieldsHidden: false,
         });
         // change the country back to GB
         if (this.country !== undefined) {

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -21,7 +21,7 @@ class PostcodeLookup extends Component {
       showErrorMessages: false,
       previousAddress: '',
       isAddressSelectHidden: true,
-      isHidden: true,
+      isAddressFieldsHidden: true,
       validation: {
         postcode: {
           valid: null,
@@ -99,7 +99,7 @@ class PostcodeLookup extends Component {
         this.setState({
           ...this.state,
           showErrorMessages: true,
-          isHidden: false,
+          isAddressFieldsHidden: false,
         });
       }
     }
@@ -281,9 +281,10 @@ class PostcodeLookup extends Component {
           },
           isHidden: false,
         });
-        // this.showAddressFields();
         // change the country back to GB
-        // this.country.selectedIndex = 0;
+        if (this.country !== undefined) {
+          this.country.selectedIndex = 0;
+        }
       }
     }
   }
@@ -291,7 +292,7 @@ class PostcodeLookup extends Component {
   showAddressFields(e) {
     e.preventDefault();
     this.setState({
-      isHidden: false,
+      isAddressFieldsHidden: false,
     });
   }
 
@@ -400,7 +401,7 @@ class PostcodeLookup extends Component {
           className="form__field--address-detail"
         >
           {
-            this.state.isHidden === false &&
+            this.state.isAddressFieldsHidden === false &&
             <div>
               { addressOuptutFields.map(item => (
                 <InputField

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -21,6 +21,7 @@ class PostcodeLookup extends Component {
       showErrorMessages: false,
       previousAddress: '',
       addressSelectClass: 'visually-hidden',
+      isHidden: true,
       validation: {
         postcode: {
           valid: null,
@@ -95,10 +96,11 @@ class PostcodeLookup extends Component {
         showErrorMessages: nextProps.showErrorMessages,
       });
       if (nextProps.showErrorMessages === true) {
-        this.removeClassName(this.addressDetailRef, 'visually-hidden');
+        // this.removeClassName(this.addressDetailRef, 'visually-hidden');
         this.setState({
           ...this.state,
           showErrorMessages: true,
+          isHidden: false,
         });
       }
     }
@@ -278,10 +280,11 @@ class PostcodeLookup extends Component {
               message: '',
             },
           },
+          isHidden: false,
         });
-        this.showAddressFields();
+        // this.showAddressFields();
         // change the country back to GB
-        this.country.selectedIndex = 0;
+        // this.country.selectedIndex = 0;
       }
     }
   }
@@ -291,6 +294,9 @@ class PostcodeLookup extends Component {
       e.preventDefault();
     }
     this.removeClassName(this.addressDetailRef, 'visually-hidden');
+    this.setState({
+      isHidden: false,
+    });
   }
 
   /**
@@ -334,6 +340,7 @@ class PostcodeLookup extends Component {
    * @return {*}
    */
   render() {
+    console.log(this.state.isHidden);
     const postCodeField = {
       id: 'postcode',
       type: 'text',
@@ -392,38 +399,42 @@ class PostcodeLookup extends Component {
         <div
           ref={this.setAddressDetailRef}
           id="address-detail"
-          className="form__fieldset form__field--address-detail visually-hidden"
+          className="form__fieldset form__field--address-detail"
         >
           {
-            addressOuptutFields.map(item => (
-              <InputField
-                key={item.id}
+            this.state.isHidden === false &&
+            <div>
+              { addressOuptutFields.map(item => (
+                <InputField
+                  key={item.id}
+                  ref={this.setRefs}
+                  id={item.id}
+                  type={item.type}
+                  name={item.id}
+                  label={item.label}
+                  required={item.required}
+                  value={id => this.addressValue(id)}
+                  pattern={item.pattern}
+                  invalidErrorText={item.invalidErrorText}
+                  showErrorMessage={this.state.showErrorMessages}
+                  fieldValue={this.state.validation[item.id].value}
+                  isValid={(valid, name) => { this.setValidity(name, valid); }}
+                />
+              ))
+              }
+              <SelectField
                 ref={this.setRefs}
-                id={item.id}
-                type={item.type}
-                name={item.id}
-                label={item.label}
-                required={item.required}
-                value={id => this.addressValue(id)}
-                pattern={item.pattern}
-                invalidErrorText={item.invalidErrorText}
+                id="country"
+                name="country"
+                label="Country"
+                required
+                options={this.state.countryDropdownList}
+                value={() => this.state.validation.country.value}
                 showErrorMessage={this.state.showErrorMessages}
-                fieldValue={this.state.validation[item.id].value}
                 isValid={(valid, name) => { this.setValidity(name, valid); }}
               />
-            ))
+            </div>
           }
-          <SelectField
-            ref={this.setRefs}
-            id="country"
-            name="country"
-            label="Country"
-            required
-            options={this.state.countryDropdownList}
-            value={() => this.state.validation.country.value}
-            showErrorMessage={this.state.showErrorMessages}
-            isValid={(valid, name) => { this.setValidity(name, valid); }}
-          />
         </div>
       </div>
     );

--- a/src/components/PostcodeLookup/PostcodeLookup.js
+++ b/src/components/PostcodeLookup/PostcodeLookup.js
@@ -290,10 +290,7 @@ class PostcodeLookup extends Component {
   }
 
   showAddressFields(e) {
-    if (e !== undefined) {
-      e.preventDefault();
-    }
-    this.removeClassName(this.addressDetailRef, 'visually-hidden');
+    e.preventDefault();
     this.setState({
       isHidden: false,
     });
@@ -340,7 +337,7 @@ class PostcodeLookup extends Component {
    * @return {*}
    */
   render() {
-    console.log(this.state.isHidden);
+    // console.log(this.state.isHidden);
     const postCodeField = {
       id: 'postcode',
       type: 'text',
@@ -394,7 +391,7 @@ class PostcodeLookup extends Component {
           isValid={(valid, name, value) => { this.updateAddress(value); }}
         />
         <div className="form__field--wrapper">
-          <a href="" role="button" className="link" onClick={e => this.showAddressFields(e)}>Or enter your address manually</a>
+          <a href="/" role="button" className="link" onClick={e => this.showAddressFields(e)}>Or enter your address manually</a>
         </div>
         <div
           ref={this.setAddressDetailRef}

--- a/src/components/RadioButtons/RadioButtons.js
+++ b/src/components/RadioButtons/RadioButtons.js
@@ -1,6 +1,7 @@
 /* eslint-env browser */
 import React, { Component } from 'react';
 import propTypes from 'prop-types';
+import browser from 'browser-detect';
 import './RadioButtons.scss';
 
 const shortid = require('shortid');
@@ -199,6 +200,10 @@ class RadioButtons extends Component {
   render() {
     const errorClass = this.state.showErrorMessage === true ? 'form__field-error-wrapper' : '';
     const extraClass = this.props.extraClass !== '' ? this.props.extraClass : '';
+    const isBrowser = browser();
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ?
+      { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
+
     return (
       <fieldset
         id={this.props.id}
@@ -215,8 +220,7 @@ class RadioButtons extends Component {
         <div
           id={`field-error--${this.props.id}`}
           className="form__field-error-container form__field-error-container--radio"
-          aria-live="assertive"
-          role="status"
+          {...supportedAriaAttributes}
         >
           <span className="form-error">
             {this.state.message}

--- a/src/components/RadioButtons/package.json
+++ b/src/components/RadioButtons/package.json
@@ -7,6 +7,7 @@
     "react": "^16.3.1",
     "prop-types": "^15.6.1",
     "shortid": "^2.2.13",
-    "react-markdown": "^3.4.1"
+    "react-markdown": "^3.4.1",
+    "browser-detect": "^0.2.28"
   }
 }

--- a/src/components/SelectField/SelectField.js
+++ b/src/components/SelectField/SelectField.js
@@ -176,7 +176,6 @@ class SelectField extends Component {
         <div
           id={`field-error--${this.props.id}`}
           className="form__field-error-container form__field-error-container--select"
-          aria-live="assertive"
           {...supportedAriaAttributes}
         >
           <span className="form-error">

--- a/src/components/SelectField/SelectField.js
+++ b/src/components/SelectField/SelectField.js
@@ -144,7 +144,7 @@ class SelectField extends Component {
     const errorClass = this.state.showErrorMessage === true ? 'form__field-error-wrapper' : '';
     const extraClass = this.props.extraClass !== '' ? this.props.extraClass : '';
     const isBrowser = browser();
-    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { role: 'alert', 'aria-relevant': 'all' } : { role: 'status' };
+    const supportedAriaAttributes = isBrowser.name === 'firefox' && isBrowser.os.match('Windows') ? { 'aria-live': 'assertive', 'aria-relevant': 'additions removals' } : { 'aria-live': 'assertive', role: 'status' };
 
     return (
       <div


### PR DESCRIPTION
- Changed the error message so that they will re-read the messages again in Firefox
- Changed the postcode lookup to be totally hidden so that the fields as not read out, don't allow the ability to tab hidden fields.
- Added a check to reset country selection on re-selection