### PR TITLE
inputfield email validation fix

### DIFF
--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -117,4 +117,3 @@ export default function fieldValidation(props, validation) {
   }
   return validation;
 }
-

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -1,7 +1,7 @@
 const defaultValidationPatterns = {
   tel: /^[0-9 ]{11,}$/,
   number: /^[0-9]+$/,
-  email: /^([A-Za-z0-9_+-]+\.?)*[A-Za-z0-9_+-]+@[A-Za-z0-9]+([A-Za-z0-9_-]+\.?)*[A-Za-z0-9]+\.[A-Za-z]{2,3}$/,
+  email: /^([A-Za-z0-9_+-]+\.?)*[A-Za-z0-9_+-]+@[A-Za-z0-9]+([A-Za-z0-9_-]+\.?)*[A-Za-z0-9]+\.[A-Za-z]{2,}$/,
   text: /^[\sA-Za-z0-9_.'&-]+$/,
 };
 


### PR DESCRIPTION
we were only allowing  2 or 3 characters after the . at the end of the email string (.uk / .com for example)
Now it needs at least 2 characters or more after the dot.

Preview on Giftaid: https://deploy-preview-161--giftaid-react.netlify.com/
Preview on Donate: https://deploy-preview-549--comicrelief-donation.netlify.com/