### PR TITLE
Partner link from footer do not point to sr.com 

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -92,7 +92,7 @@ class Menu extends Component {
                   <li className="menu-item" key={`${type}-menu-${title}`}>
                     {(url.indexOf('http') !== -1) ?
                       <a href={url} rel="noopener noreferrer" target="_blank">{title}</a> :
-                      <a href={baseUrl + url}>{title}</a>}
+                      <a href={url === ('/partners') ? 'https://www.sportrelief.com/partners' : baseUrl + url}>{title}</a>}
                   </li>
                 );
               }


### PR DESCRIPTION
Fixes #386 
When trying to access partner link (SR campaign) on footer it doesn't point to https://www.sportrelief.com/partners
Ref https://storybook.services.comicrelief.com/undefined/partners