### PR TITLE
ENG-2879: PCLU ux improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comicrelief/storybook",
   "description": "React components to build the Comic Relief front-end experience",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "dependencies": {
     "@snyk/protect": "^1.1060.0",
     "@storybook/addon-info": "3",

--- a/src/components/PostcodeLookup/postcodeValidations.js
+++ b/src/components/PostcodeLookup/postcodeValidations.js
@@ -1,8 +1,8 @@
 // Passed to the PCLU component as default prop value
 const defaultPostcodeValidation = {
   GB: {
-    pattern: '(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})',
-    errorMsg: 'Please enter a valid UK postcode, using a space and capital letters',
+    pattern: '(GIR 0AA)|((([A-Za-z][0-9][0-9]?)|(([A-Za-z][A-Ha-hJ-Yj-y][0-9][0-9]?)|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})',
+    errorMsg: 'Please enter a valid UK postcode, using a space',
   },
 };
 


### PR DESCRIPTION
This work allows for lowercase input in the PCLU postcode field; this doesn't interfere with the Lookup service at all as it's case insensitive.

**BEFORE:**

![Screenshot 2023-11-14 at 11 36 06](https://github.com/comicrelief/storybook/assets/4737220/8c4c994e-caad-4fd1-95f1-6acc2535894d)

---

**AFTER** (the postcode gets transformed to uppercase as part of the API integration):

![Screenshot 2023-11-14 at 11 35 41](https://github.com/comicrelief/storybook/assets/4737220/cfc509e0-cc26-485d-be86-84d7ec0ac551)

![Screenshot 2023-11-14 at 11 35 47](https://github.com/comicrelief/storybook/assets/4737220/26ef6504-717b-4273-b598-d77f40bf5cb9)
