### PR TITLE
ENG-2955: improve MP phone validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comicrelief/storybook",
   "description": "React components to build the Comic Relief front-end experience",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "dependencies": {
     "@snyk/protect": "^1.1060.0",
     "@storybook/addon-info": "3",

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -24,7 +24,7 @@ async function runYupValidation(type, value) {
   if (type === 'email') {
     fieldObj = { thisField: yup.string().email() };
   } else if (type === 'tel') {
-    fieldObj = { thisField: yup.string().phone('GB', true).matches(/^[+]{0,1}[0-9]*$/) };
+    fieldObj = { thisField: yup.string().phone('GB', true).matches(/^[+]{0,1}[0-9]{11, 12}$/) };
   } else {
     fieldObj = { thisField: yup.string() }; // Fallback, just in case
   }


### PR DESCRIPTION
Quick update to the regex pattern used to specify 11 or 12 characters, to allow the `+448081570192`format, as well as the  `08081570192` format, but nothing shorter, as per the B/E validation issue in https://comicrelief.atlassian.net/browse/ENG-2940