### PR TITLE
fix: Don't use 'strict' Yup rule flag for GB tel check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@comicrelief/storybook",
   "description": "React components to build the Comic Relief front-end experience",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "dependencies": {
     "@snyk/protect": "^1.1060.0",
     "@storybook/addon-info": "3",

--- a/src/components/InputField/validation.js
+++ b/src/components/InputField/validation.js
@@ -24,7 +24,7 @@ async function runYupValidation(type, value) {
   if (type === 'email') {
     fieldObj = { thisField: yup.string().email() };
   } else if (type === 'tel') {
-    fieldObj = { thisField: yup.string().phone('GB', true).matches(/^[+]{0,1}[0-9]{11,12}$/) };
+    fieldObj = { thisField: yup.string().phone('GB').matches(/^[+]{0,1}[0-9]{11,12}$/) };
   } else {
     fieldObj = { thisField: yup.string() }; // Fallback, just in case
   }


### PR DESCRIPTION
https://comicrelief.atlassian.net/browse/ENG-3089

It looks like that area code was from from the Isle Of Man, so not strictly GB

_* Once again, there are a number of exceptions to this rule. Besides the allocation of 070 and 076 to personal numbers and pagers, there are also allocated phone number ranges for the Isle of Man (**07524**, 07624, 07924), Jersey (07509, 07700, 07797, 07829, 07937) and Guernsey (07781, 07839, 07911)_

https://kenstechtips.com/index.php/uk-telephone-numbering-cost-from-mobile

